### PR TITLE
fix build error (handlerrepo -> handler)

### DIFF
--- a/gtkcord/components/popup/stateful.go
+++ b/gtkcord/components/popup/stateful.go
@@ -7,7 +7,7 @@ import (
 	"github.com/diamondburned/gtkcord3/gtkcord/ningen"
 	"github.com/diamondburned/gtkcord3/gtkcord/semaphore"
 	"github.com/diamondburned/gtkcord3/internal/log"
-	"github.com/diamondburned/ningen/handlerrepo"
+	"github.com/diamondburned/ningen/handler"
 	"github.com/gotk3/gotk3/gtk"
 )
 


### PR DESCRIPTION
So I was trying to build gtk for #93 and I kept getting an error:
```
gtkcord/components/popup/stateful.go:10:2: module github.com/diamondburned/ningen@latest found (v0.1.0), but does not contain package github.com/diamondburned/ningen/handlerrepo
```
But I knew the aur package worked, so I checked out what they did, and they have a patch: https://aur.archlinux.org/cgit/aur.git/tree/fix-build.patch?h=gtkcord3-git which fixes this build. This PR is just applying the patch.